### PR TITLE
Update guardianSource URL for resource fetching

### DIFF
--- a/itemLookup.ts
+++ b/itemLookup.ts
@@ -693,7 +693,7 @@ export async function downloadItems() {
     }
     const itemSource = "https://raw.githubusercontent.com/sstokic-tgm/JFTSE/development/auth-server/src/main/resources/res";
     const gachaSource = "https://raw.githubusercontent.com/sstokic-tgm/JFTSE/development/game-server/src/main/resources/res/lottery";
-    const guardianSource = "https://raw.githubusercontent.com/sstokic-tgm/JFTSE/development/emulator/src/main/resources/res"
+    const guardianSource = "https://raw.githubusercontent.com/sstokic-tgm/JFTSE/development/server-core/src/main/resources/res";
     const itemURL = itemSource + "/Item_Parts_Ini3.xml";
     const itemData = download(itemURL);
     //const shopURL = itemSource + "/Shop_Ini3.xml";


### PR DESCRIPTION
Took longer, but its only just a different location 💯  What about not relying anymore on that file, you needed it for the Gacha drops available within the guardian mode?